### PR TITLE
Fix Multi Fluid Tank edge cases and capacity sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,9 @@ dependencies {
         jarJar.pin(it, project.create_dragon_lib_version)
     }
 
-    implementation fg.deobf("plus.dragons.createdragonlib:create_dragon_lib-${minecraft_version}:${create_dragon_lib_version}")
+    implementation(fg.deobf("plus.dragons.createdragonlib:create_dragon_lib-${minecraft_version}:${create_dragon_lib_version}") {
+        transitive = false
+    })
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=CreateFluidStuffs
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.2.0
+mod_version=1.2.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/moepus/createfluidstuffs/content/tank/MultiFluidTankBlockEntity.java
+++ b/src/main/java/com/moepus/createfluidstuffs/content/tank/MultiFluidTankBlockEntity.java
@@ -248,8 +248,7 @@ public class MultiFluidTankBlockEntity extends SmartBlockEntity implements IHave
         if (level.isClientSide)
             return;
         updateConnectivity = true;
-        if (!keepFluids)
-            applyFluidTankSize(1);
+        applyFluidTankSize(1);
         controller = null;
         width = 1;
         height = 1;

--- a/src/main/java/com/moepus/createfluidstuffs/foundation/fluid/SmartMultiFluidTank.java
+++ b/src/main/java/com/moepus/createfluidstuffs/foundation/fluid/SmartMultiFluidTank.java
@@ -117,7 +117,30 @@ public class SmartMultiFluidTank implements IFluidHandler, IFluidTank {
 
     @Override
     public int getTankCapacity(int tank) {
-        return getCapacity();
+        if (tank < 0 || tank >= getTanks()) {
+            return 0;
+        }
+
+        int amountInTank = multi_fluid[tank].getAmount();
+        if (!multi_fluid[tank].isEmpty()) {
+            return amountInTank;
+        }
+
+        int firstEmptyTank = -1;
+        for (int i = 0; i < getTanks(); i++) {
+            if (multi_fluid[i].isEmpty()) {
+                firstEmptyTank = i;
+                break;
+            }
+        }
+
+        // Report all remaining free capacity on only one empty slot so total reported
+        // capacity stays equal to the real shared tank capacity.
+        if (firstEmptyTank == tank) {
+            return getSpace();
+        }
+
+        return 0;
     }
 
     @Override
@@ -148,8 +171,8 @@ public class SmartMultiFluidTank implements IFluidHandler, IFluidTank {
             return 0;
 
         OptionalInt target_tank_opt = getFirstAvailableTank(resource);
+        if (target_tank_opt.isEmpty()) return 0;
         if (action.simulate()) {
-            if (target_tank_opt.isEmpty()) return 0;
             return Math.min(getSpace(), resource.getAmount());
         }
 


### PR DESCRIPTION
Fix Multi Fluid Tank edge cases and capacity sync:

- Prevent crash when inserting a 9th fluid type (no available slot now safely returns 0 in fill).
- Correct Jade capacity display by reporting shared capacity without multiplying by tank count
- Fix split behavior so detached single tanks reset to 1-block capacity instead of keeping merged capacity (e.g., 32B).
